### PR TITLE
fix: 允许 kotlin-reflect/okio/okhttp 解析其传递依赖 (#31)

### DIFF
--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/RuntimeEnv.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/RuntimeEnv.kt
@@ -15,16 +15,13 @@ import taboolib.common.env.RuntimeDependency
 @RuntimeDependencies(
     RuntimeDependency(
         value = "!org.jetbrains.kotlin:kotlin-reflect:2.2.0",
-        test = "!kotlin.reflect.full.KClasses",
-        transitive = false
+        test = "!kotlin.reflect.full.KClasses"
     ),
     RuntimeDependency(
-        value = "!com.squareup.okio:okio-jvm:3.6.0",
-        transitive = false
+        value = "!com.squareup.okio:okio-jvm:3.6.0"
     ),
     RuntimeDependency(
-        value = "!com.squareup.okhttp3:okhttp:4.12.0",
-        transitive = false
+        value = "!com.squareup.okhttp3:okhttp:4.12.0"
     ),
     RuntimeDependency(
         value = "!com.google.code.gson:gson:2.11.0",


### PR DESCRIPTION
## 问题
- #31 `KotlinReflectionNotSupportedError` —— 在隔离类加载器下 `/bv qrcode` 绑定失败。
- #27 `okio.Options does not have member field 'okio.Options$Companion Companion'` / `Could not initialize class okhttp3.internal.Util` —— 依赖冲突。

## 根因
`RuntimeEnv.kt` 中三个运行时依赖均显式声明 `transitive = false`：

```kotlin
RuntimeDependency(value = "!org.jetbrains.kotlin:kotlin-reflect:2.2.0", transitive = false)
RuntimeDependency(value = "!com.squareup.okio:okio-jvm:3.6.0", transitive = false)
RuntimeDependency(value = "!com.squareup.okhttp3:okhttp:4.12.0", transitive = false)
```

- Ktorm DSL 在 `db.from(Table).select().where { ... }` 链中通过 Kotlin 属性引用 (`Table.column`) 解析列字段，依赖 `kotlin-reflect`；而 `kotlin-reflect 2.2.0` 需要配套的 `kotlin-stdlib 2.2.0`。`transitive = false` 使 TabooLib 仅拉取 `kotlin-reflect` 自身、不附带匹配版本的 stdlib。
- 在 lophine 1.21.11 + Java 25 等服务端环境，本地 Kotlin stdlib 版本与 TabooLib 下载的 `kotlin-reflect` 不一致，导致反射初始化失败：`KotlinReflectionNotSupportedError`。
- `okhttp 4.12.0` 内置对 `okio 3.6.0` 的依赖；两个 jar 都声明 `transitive = false` 后，端服原生的 okio 与插件类加载器中的 okio 可能并存，触发 `NoSuchFieldError: okio.Options$Companion Companion`。

## 修复
去掉上述三条 `RuntimeDependency` 上的 `transitive = false`，让 TabooLib 按 Maven 坐标的传递依赖解析自动拉取匹配的 `kotlin-stdlib` 与 `okio`，消除类加载器上的版本/副本错位。

仅影响依赖加载行为，未改动任何业务代码。

## 验证
- `./gradlew taboolibBuildApi` 构建通过，仅遗留 MapPalette / setMapId 的既有 deprecation 警告。

Closes #31