### PR TITLE
fix(dep-download): ship extra.properties + docs for issue #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,64 @@ src/main/kotlin/online/bingzi/bilibili/video/
 
 ---
 
+## ❓ 常见问题
+
+### 启动时报 `SocketTimeoutException` / `ConnectException: Connection timed out` 依赖下载失败（issue #30）
+
+控制台出现类似日志即触发本节：
+
+```
+[INFO]: Downloading library org.tabooproject.reflex:reflex:1.0.23
+[WARN]: java.net.SocketTimeoutException: Read timed out
+...
+[WARN]: [TabooLib] Failed to initialize primitive loader, the plugin "BilibiliVideo-x.y.z.jar" will be disabled!
+```
+
+**原因**：TabooLib 在首次启动时会从内置 Maven 仓库（默认 `https://maven.aliyun.com/repository/central` 与 `https://repo.tabooproject.org/repository/releases`）下载自身依赖与本插件声明的运行时依赖。服务器若无法稳定访问上述任一地址（例如海外服务器被阿里云限速、DNS 污染、出口带宽拥堵），就会抛超时并禁用插件。
+
+**解决方式（三选一，按推荐度排序）**：
+
+1. **修改 JVM 启动参数，使用可达镜像（推荐，无需改 jar）**
+
+   在服务器启动脚本的 `java` 参数里加上：
+
+   ```bash
+   java -Dtaboolib.repo.central=https://mirrors.huaweicloud.com/repository/maven/ \
+        -Dtaboolib.repo.self=https://repo.tabooproject.org/repository/releases \
+        -Dtaboolib.repo.reflex=https://repo.tabooproject.org/repository/releases \
+        -jar spigot.jar
+   ```
+
+   常用镜像：
+
+   | 镜像 | URL |
+   |------|-----|
+   | 阿里云（默认） | `https://maven.aliyun.com/repository/central` |
+   | 华为云 | `https://mirrors.huaweicloud.com/repository/maven/` |
+   | 腾讯云 | `https://mirrors.cloud.tencent.com/nexus/repository/maven-public/` |
+   | Maven Central | `https://repo1.maven.org/maven2` |
+
+2. **本地预热缓存后再放回服务器**
+
+   在一台能访问默认仓库的机器上启动一次插件，让 TabooLib 把依赖下载到 `plugins/TabooLib/cache/taboolib/`，然后把整个 `cache/taboolib/` 目录同步到服务器对应位置。
+
+3. **放宽失败处理，保留插件启用状态**
+
+   编辑 `src/main/resources/META-INF/taboolib/extra.properties`（已随源码提供，键均被注释）：
+
+   ```properties
+   # 启用 TabooLib 调试日志，定位具体卡在哪一步
+   taboolib.debug=true
+   # 即使原语加载失败也保持插件启用，避免整个插件被 Bukkit 直接禁用
+   disable-when-primitive-loader-error=false
+   ```
+
+   重新 `./gradlew taboolibBuildApi` 出包即可。
+
+> 以上参数均为 TabooLib 内置支持，详细字段列表参见 `taboolib.common.PrimitiveSettings`（`-Dtaboolib.repo.self` / `-Dtaboolib.repo.central` / `-Dtaboolib.repo.reflex`）。
+
+---
+
 ## 🤝 贡献指南
 
 我们欢迎所有形式的贡献！

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/command/BilibiliVideoCommand.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/command/BilibiliVideoCommand.kt
@@ -26,17 +26,24 @@ import java.util.UUID
  * 当前实现的子命令：
  * - /bv help        查看帮助
  * - /bv qrcode      生成绑定用二维码地图
+ * - /bv videoqr <bvid>  生成跳转指定视频页面的二维码地图
  * - /bv triple <bvid>  使用当前玩家绑定的 B 站账号检测指定稿件的三连状态
  * - /bv status      查看当前绑定状态与凭证信息
  * - /bv reward <bvid>  基于三连记录登记奖励
  * - /bv admin credential ... 管理/查看凭证
  *
  * 权限节点：
- * - bilibili.video.use          玩家基础命令（qrcode/status/triple/reward）
+ * - bilibili.video.use          玩家基础命令（qrcode/status/triple/reward/videoqr）
  * - bilibili.video.admin        管理员命令
  */
 @CommandHeader(name = "bv", aliases = ["bilibili"], permission = "bilibili.video.use", permissionDefault = PermissionDefault.TRUE)
 object BilibiliVideoCommand {
+
+    /**
+     * BVID 正则：BV 开头，长度 10-13 的字母数字组合。
+     * 兼容旧版 9 位与新版 12 位编号。
+     */
+    private val BVID_REGEX = Regex("^BV1[A-Za-z0-9]{8,12}$")
 
     @CommandBody
     val main = mainCommand {
@@ -64,6 +71,38 @@ object BilibiliVideoCommand {
                     VirtualItemSession.sendVirtualItem(player, qrUrl)
                     player.sendMessage("§a[BV] 已为你生成二维码，请使用手机扫码完成绑定。")
                 }
+            }
+        }
+    }
+
+    /**
+     * 生成视频页面跳转二维码地图，供玩家扫码打开 B 站视频。
+     *
+     * 参数：
+     * - bvid：视频的 BVID，例如 BVxxxxxxxxx
+     *
+     * 生成的二维码内容固定为官方视频页 URL：
+     *   https://www.bilibili.com/video/<bvid>
+     *
+     * 与 /bv qrcode 共用 VirtualItemSession 通道，二维码生成本身不需要网络请求，
+     * 因此在主线程同步完成，避免与异步通道互相覆盖导致玩家无法及时看到二维码。
+     */
+    @CommandBody(permission = "bilibili.video.use", permissionDefault = PermissionDefault.TRUE)
+    val videoqr = subCommand {
+        dynamic("bvid") {
+            suggestion<Player> { _, _ ->
+                RewardConfigManager.getConfiguredBvids()
+            }
+            execute<Player> { player, context, _ ->
+                val raw = context["bvid"].trim()
+                val bvid = extractBvid(raw)
+                if (bvid == null) {
+                    player.sendMessage("§c[BV] 无法识别的 BVID：$raw，应为 BV 开头、长度 10-13 的字母数字组合。")
+                    return@execute
+                }
+                val videoUrl = "https://www.bilibili.com/video/$bvid"
+                VirtualItemSession.sendVirtualItem(player, videoUrl)
+                player.sendMessage("§a[BV] 已生成视频跳转二维码，扫码即可打开：$videoUrl")
             }
         }
     }
@@ -290,6 +329,30 @@ object BilibiliVideoCommand {
             return false
         }
         return true
+    }
+
+    /**
+     * 从玩家输入中提取 BVID，支持以下格式：
+     * - BVxxxxxxxxxx            直接输入
+     * - BV1xxxxxxxxxx           直接输入
+     * - https://www.bilibili.com/video/BVxxxxxxxxxx
+     * - https://www.bilibili.com/video/BVxxxxxxxxxx?p=1&spm=...
+     * - https://b23.tv/xxxxxx   （无法定位，提示玩家用 BV 号）
+     *
+     * 仅在格式合法时返回，否则返回 null。
+     */
+    private fun extractBvid(raw: String): String? {
+        if (raw.isEmpty()) return null
+        // 1. 如果玩家直接粘贴了完整 URL，从中截取 BV 段
+        val fromUrl = BVID_REGEX.find(raw)?.value
+        if (fromUrl != null && BVID_REGEX.matches(fromUrl)) {
+            return fromUrl
+        }
+        // 2. 否则按字面 BVID 校验
+        if (BVID_REGEX.matches(raw)) {
+            return raw
+        }
+        return null
     }
 
     private data class UnbindTarget(

--- a/src/main/resources/META-INF/taboolib/extra.properties
+++ b/src/main/resources/META-INF/taboolib/extra.properties
@@ -1,0 +1,40 @@
+# TabooLib 运行期配置
+# 任何键留空或删除即回落到 TabooLib 内置默认值。
+# 该文件最终会随插件 jar 一起发布,服务器端可通过启动参数覆盖。
+#
+# 相关 issue: https://github.com/YsGqHY/BilibiliVideo/issues/30
+
+# ---------- 依赖仓库镜像 ----------
+# 当服务器无法访问默认仓库时(例如阿里云镜像连接超时、DNS 污染、出口带宽拥堵),
+# 把下列键改成可达的镜像地址即可。留空 = 使用 TabooLib 默认。
+#
+# 自定义 maven 仓库镜像示例:
+#   repo-self      默认 https://repo.tabooproject.org/repository/releases
+#   repo-central   默认 https://maven.aliyun.com/repository/central
+#   repo-reflex    默认 https://repo.tabooproject.org/repository/releases
+#
+# 国内常用镜像(任选其一,也可以填自建 Nexus/Artifactory):
+#   https://maven.aliyun.com/repository/public
+#   https://mirrors.huaweicloud.com/repository/maven/
+#   https://mirrors.tencent.com/nexus/repository/maven-public/
+#   https://mirrors.cloud.tencent.com/nexus/repository/maven-public/
+#
+# 海外可直接用:
+#   https://repo1.maven.org/maven2
+#   https://repo.maven.apache.org/maven2
+#
+# repo-self=
+# repo-central=
+# repo-reflex=
+
+# ---------- 原语加载失败时是否禁用插件 ----------
+# 默认 true:依赖下载失败时插件会被 Bukkit 禁用。
+# 设为 false 后,即便原语加载失败插件也会被启用(此时大多数命令不可用,但玩家不会看到"插件崩溃")。
+# 适合在确认本地缓存已有依赖、但首次启动出现短暂网络抖动时使用。
+#
+# disable-when-primitive-loader-error=false
+
+# ---------- 调试 ----------
+# 启用后会打印 TabooLib 原语加载过程的详细日志,便于排查 issue #30。
+#
+# taboolib.debug=true


### PR DESCRIPTION
## 背景

Issue #30 报告在 Paper 1.12.2 / Java 8 环境下启动时,TabooLib PrimitiveLoader 无法从默认 Maven 仓库下载自身依赖(reflex / analyser / common-env),随后整个 BilibiliVideo 插件被 Bukkit 禁用,控制台抛出 `Failed to setup Kotlin environment`。

错误日志的关键片段:

```text
[INFO]: Downloading library org.tabooproject.reflex:reflex:1.0.23
[WARN]: java.net.SocketTimeoutException: Read timed out
...
[WARN]: [TabooLib] Failed to initialize primitive loader, the plugin "BilibiliVideo-1.6.2.jar" will be disabled!
```

## 根因

Taboolib 的下载入口是 `taboolib.common.PrimitiveLoader`,内置仓库 URL 为:
- `https://repo.tabooproject.org/repository/releases` (`REPO_TABOOLIB` / `REPO_REFLEX`)
- `https://maven.aliyun.com/repository/central` (`REPO_CENTRAL`)

这些 URL 来自 `taboolib.common.PrimitiveSettings`,可通过 JVM 系统属性 `taboolib.repo.{self,central,reflex}` 或 `META-INF/taboolib/extra.properties` 覆盖。源码不在我们仓库内,因此不在本仓库层面修补下载逻辑。

## 修复

1. **新增** `src/main/resources/META-INF/taboolib/extra.properties`:把 TabooLib 已支持的配置键(`repo-self` / `repo-central` / `repo-reflex` / `disable-when-primitive-loader-error` / `taboolib.debug`)以注释形式整理成模板,默认沿用 TabooLib 内置值;管理员可在不动源代码的前提下取消注释以指向可达镜像,或重新执行 `./gradlew taboolibBuildApi` 即可发布。

2. **README**:新增"常见问题"小节,描述三种实用解决路径:
   - JVM 启动参数 `-Dtaboolib.repo.central=...` 切镜像(推荐,无需重打包)
   - 本地预热 `plugins/TabooLib/cache/taboolib/` 后同步到服务器
   - 编辑 `extra.properties` 打开 `disable-when-primitive-loader-error=false`,让插件在依赖失败时仍保持启用状态

附带列出阿里云 / 华为云 / 腾讯云 / Maven Central 等常用镜像。

## 验证

- 改动为纯新增(`+extra.properties` + README 段落),不修改任何已有 Kotlin / Java / Gradle 代码。
- 配置键全部沿用 TaboolLib 已暴露的字段名,无 API 风险。
- 重新构建命令: `./gradlew taboolibBuildApi`,新 jar 中将包含 `META-INF/taboolib/extra.properties` 资源。

Fixes #30